### PR TITLE
Fix listbibl.xsl not respecting dark mode and not allowing navigation back in created html

### DIFF
--- a/{{cookiecutter.directory_name}}/xslt/listbibl.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/listbibl.xsl
@@ -82,7 +82,6 @@
                     </div>
                 </main>
                 <xsl:call-template name="html_footer"/>
-                <xsl:call-template name="html_footer"/>
                 <xsl:call-template name="tabulator_js"/>
             </body>
         </html>


### PR DESCRIPTION
When creating a project with cookiecutter, and using the navbar to navigate to **Register > Werke** , Darkmode setting is not respected and navigating back using **Register** is not possible.  This is somehow caused by `listbibl.xsl` calling the `html_footer` template twice.

https://github.com/acdh-oeaw/dse-static-cookiecutter/blob/76853bd1bf82ba731dd5807123221ca1f9c5c01b/%7B%7Bcookiecutter.directory_name%7D%7D/xslt/listbibl.xsl#L82-L88

| BEFORE | AFTER |
| --- | --- |
| <img src=https://github.com/acdh-oeaw/dse-static-cookiecutter/assets/45312697/b3874bd9-9518-419a-9560-7187de8cac83 width="100%"> | <img src=https://github.com/acdh-oeaw/dse-static-cookiecutter/assets/45312697/6c6cd325-bf21-4bf4-a731-1e727fe1419e width="100%"> |


