### PR TITLE
feat(a11y): add skip-to-main-content link

### DIFF
--- a/{{cookiecutter.directory_name}}/html/css/style.css
+++ b/{{cookiecutter.directory_name}}/html/css/style.css
@@ -13,3 +13,8 @@ div#map {
     text-decoration: underline dotted;
     cursor: pointer;
 }
+
+/* Add buffer above main frame for skip-link focus */
+#main {
+    scroll-margin-top: 1rem;
+}

--- a/{{cookiecutter.directory_name}}/html/locales/de/translation.json
+++ b/{{cookiecutter.directory_name}}/html/locales/de/translation.json
@@ -1,4 +1,5 @@
 {
+    "navbar__skip": "Zum Inhalt springen",
     "navbar__project": "Projekt",
     "navbar__about": "Über das Projekt",
     "navbar__toc": "Editionseinheiten",

--- a/{{cookiecutter.directory_name}}/html/locales/en/translation.json
+++ b/{{cookiecutter.directory_name}}/html/locales/en/translation.json
@@ -1,4 +1,5 @@
 {
+    "navbar__skip": "Skip to main content",
     "navbar__project": "Project",
     "navbar__about": "About the project",
     "navbar__toc": "Edition units",

--- a/{{cookiecutter.directory_name}}/html/locales/it/translation.json
+++ b/{{cookiecutter.directory_name}}/html/locales/it/translation.json
@@ -1,4 +1,5 @@
 {
+    "navbar__skip": "Vai al contenuto",
     "navbar__project": "Progetto",
     "navbar__about": "Sul progetto",
     "navbar__toc": "Unità di edizione",

--- a/{{cookiecutter.directory_name}}/xslt/404.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/404.xsl
@@ -24,7 +24,7 @@
             </head>            
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">

--- a/{{cookiecutter.directory_name}}/xslt/editions.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/editions.xsl
@@ -47,7 +47,7 @@
             </head>
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">

--- a/{{cookiecutter.directory_name}}/xslt/imprint.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/imprint.xsl
@@ -22,7 +22,7 @@
             
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">

--- a/{{cookiecutter.directory_name}}/xslt/index.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/index.xsl
@@ -27,7 +27,7 @@
             </head>            
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <div class="container">
                         <xsl:call-template name="one_time_alert"/>
                         <h1><xsl:value-of select="$project_short_title"/></h1>

--- a/{{cookiecutter.directory_name}}/xslt/listbibl.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/listbibl.xsl
@@ -36,7 +36,7 @@
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
 
-                <main class="flex-shrink-0 flex-grow-1">   
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">   
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">
@@ -124,7 +124,7 @@
 
                     <body class="d-flex flex-column h-100">
                         <xsl:call-template name="nav_bar"/>
-                        <main class="flex-shrink-0 flex-grow-1">
+                        <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                             <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                                 <ol class="breadcrumb">
                                     <li class="breadcrumb-item">

--- a/{{cookiecutter.directory_name}}/xslt/listorg.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/listorg.xsl
@@ -34,7 +34,7 @@
             
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
-                    <main class="flex-shrink-0 flex-grow-1">
+                    <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                         <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                             <ol class="breadcrumb">
                                 <li class="breadcrumb-item">
@@ -112,7 +112,7 @@
                     </head>
                     <body class="d-flex flex-column h-100">
                         <xsl:call-template name="nav_bar"/>
-                        <main class="flex-shrink-0 flex-grow-1">
+                        <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                             <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                                 <ol class="breadcrumb">
                                     <li class="breadcrumb-item">

--- a/{{cookiecutter.directory_name}}/xslt/listperson.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/listperson.xsl
@@ -36,7 +36,7 @@
             
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">
@@ -121,7 +121,7 @@
 
                     <body class="d-flex flex-column h-100">
                         <xsl:call-template name="nav_bar"/>
-                        <main class="flex-shrink-0 flex-grow-1">
+                        <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                             <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                                 <ol class="breadcrumb">
                                     <li class="breadcrumb-item">

--- a/{{cookiecutter.directory_name}}/xslt/listplace.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/listplace.xsl
@@ -43,7 +43,7 @@
             
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">
@@ -136,7 +136,7 @@
 
                     <body class="d-flex flex-column h-100">
                         <xsl:call-template name="nav_bar"/>
-                        <main class="flex-shrink-0 flex-grow-1">
+                        <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                             <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                                 <ol class="breadcrumb">
                                     <li class="breadcrumb-item">

--- a/{{cookiecutter.directory_name}}/xslt/meta.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/meta.xsl
@@ -39,7 +39,7 @@
             
             <body class="d-flex flex-column h-100">
             <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">

--- a/{{cookiecutter.directory_name}}/xslt/noske-search.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/noske-search.xsl
@@ -24,7 +24,7 @@
 
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb"
                         class="ps-5 p-3">
                         <ol class="breadcrumb">

--- a/{{cookiecutter.directory_name}}/xslt/partials/html_navbar.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/partials/html_navbar.xsl
@@ -4,6 +4,7 @@
     xmlns:tei="http://www.tei-c.org/ns/1.0"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all" version="2.0">
     <xsl:template name="nav_bar">
+        <a class="visually-hidden-focusable" href="#main" data-i18n="navbar__skip">Skip to main content</a>
         <header>
             <nav aria-label="Primary" class="navbar navbar-expand-lg bg-body-tertiary">
                 <div class="container-fluid">

--- a/{{cookiecutter.directory_name}}/xslt/partials/html_navbar_no_translations.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/partials/html_navbar_no_translations.xsl
@@ -4,6 +4,7 @@
     xmlns:tei="http://www.tei-c.org/ns/1.0"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all" version="2.0">
     <xsl:template name="nav_bar">
+        <a class="visually-hidden-focusable" href="#main">Zum Inhalt springen</a>
         <header>
             <nav aria-label="Primary" class="navbar navbar-expand-lg bg-body-tertiary">
                 <div class="container-fluid">

--- a/{{cookiecutter.directory_name}}/xslt/search.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/search.xsl
@@ -24,7 +24,7 @@
 
             <body class="d-flex flex-column h-100">
                 <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb"
                         class="ps-5 p-3">
                         <ol class="breadcrumb">

--- a/{{cookiecutter.directory_name}}/xslt/toc.xsl
+++ b/{{cookiecutter.directory_name}}/xslt/toc.xsl
@@ -32,7 +32,7 @@
             
             <body class="d-flex flex-column h-100">
             <xsl:call-template name="nav_bar"/>
-                <main class="flex-shrink-0 flex-grow-1">
+                <main id="main" tabindex="-1" class="flex-shrink-0 flex-grow-1">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb" class="ps-5 p-3">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">


### PR DESCRIPTION
Adds skip link so tab-key users can bypass navbar and jump to page content.

Changes:
- `xslt/partials/html_navbar.xsl`: `visually-hidden-focusable` skip link as first focusable element, with `data-i18n="navbar__skip"` for translation
- `xslt/partials/html_navbar_no_translations.xsl`: skip link with hardcoded German
- `xslt/*.xsl`: `id="main" tabindex="-1"` on `<main>`
- `html/locales/{en,de,it}/translation.json`: `navbar__skip` key in all three locales
- `html/css/style.css`: `croll-margin-top: 1rem` on `#main`

**Not yet tested for this repo.**